### PR TITLE
Run `npm test` instead of `pkg.scripts.test`

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ cli.on('index', function (args) {
         return done();
       }
 
-      var command = format('docker run --rm test-%s-%s %s', pkg.name, version, pkg.scripts.test);
+      var command = format('docker run --rm test-%s-%s %s', pkg.name, version, 'npm test');
 
       state[version] = STATE_RUNNING;
       updateState(state);


### PR DESCRIPTION
By doing this appropriate $PATH variables are set for binaries (such as test runners). Otherwise you will see errors such as:

```
exec: "mocha": executable file not found in $PATH
Error response from daemon: Cannot start container 6cbb5cf0a925173cc18eccbafb111553f9c1320b05d08b38f8559e39f4874105: [8] System error: exec: "mocha": executable file not found in $PATH
```