### PR TITLE
Service support

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "figures": "^1.4.0",
     "log-update": "^1.0.1",
     "mz": "^2.0.0",
+    "object-assign": "^4.0.1",
     "stable-node-version": "^1.0.0",
     "text-table": "^0.2.0",
     "yamljs": "^0.2.4"


### PR DESCRIPTION
This PR resolves #2.

It adds support for the services in `.travis.yml`. This way you can link whatever you want. The name provided in the `services` list is the name of the container (running the service), for instance mongodb. The service is then accessible in the test container via the hostname which is the same as the name of the container (e.g. mongodb).

Haven't added documentation for this because I didn't want to screw up your current docs :). If the PR is good enough for you, just let me know where to add the docs and will push the extra changes.

If you don't like the idea, no problem but I would love to have the ability of services.