### PR TITLE
Fixed exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ getVersions()
       console.log(errors[version]);
     });
 
-    process.exit(errors.length);
+    process.exit(Object.keys(errors).length);
   });
 
 


### PR DESCRIPTION
This PR resolves #4 by using `Object.keys(errors).length` instead of `errors.length` because `errors` is an object and not an array.