### PR TITLE
Make context name lower case

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ var errors = {};
 getVersions()
   .map(function (version) {
     var context = {
-      name: pkg.name,
+      name: pkg.name.toLowerCase(),
       version: version
     };
 


### PR DESCRIPTION
Resolve #8 to make sure the name of the container is lower case. If not, the `docker build` command will fail.