### PR TITLE
Catch error if src of copy does not exist

### DIFF
--- a/util/copy.js
+++ b/util/copy.js
@@ -18,8 +18,12 @@ module.exports = copy;
  * Synchronously copy file
  */
 
-function copy (src, dest) {
-	var source = fs.readFileSync(src);
+function copy(src, dest) {
+	try {
+		var source = fs.readFileSync(src);
 
-	fs.writeFileSync(dest, source);
+		fs.writeFileSync(dest, source);
+	} catch (err) {
+		
+	}
 }


### PR DESCRIPTION
Fixes #16 

Not sure if we want to never throw this error. Another possibility is to add a `copySafe` method that safely copies without throwing an error if an error occurs and keep the original `copy` as it was.

Let me know what you think and I'll push the changes.