### PR TITLE
Parse .travis.yml in separate method

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ var fs = require('mz/fs');
 var updateState = require('./lib/update-state');
 var getVersions = require('./lib/get-versions');
 var pullImage = require('./lib/pull-image');
+var parseConfig = require('./lib/parse-config');
 var states = require('./lib/states');
 var clean = require('./lib/clean');
 var build = require('./lib/build');
@@ -71,7 +72,9 @@ if (!exists) {
 var state = {};
 var errors = {};
 
-getVersions(join(path, '.travis.yml'))
+var config = parseConfig(join(path, '.travis.yml'));
+
+getVersions(config)
 	.map(function (version) {
 		var context = {
 			version: version,

--- a/lib/get-versions.js
+++ b/lib/get-versions.js
@@ -4,9 +4,8 @@
  * Dependencies
  */
 
+var Promise = require('bluebird');
 var fetchStableVersion = require('stable-node-version');
-var yaml = require('yamljs');
-var fs = require('mz/fs');
 
 
 /**
@@ -20,16 +19,12 @@ module.exports = getVersions;
  * Get requested Node.js versions
  */
 
-function getVersions (path) {
-	return fs.readFile(path, 'utf-8')
-		.then(function (source) {
-			return yaml.parse(source).node_js || ['stable'];
-		})
-		.map(function (version) {
-			if (version === 'stable') {
-				return fetchStableVersion();
-			}
+function getVersions (config) {
+	return Promise.resolve(config.node_js || ['stable']).map(function (version) {
+		if (version === 'stable') {
+			return fetchStableVersion();
+		}
 
-			return version;
-		});
+		return version;
+	});
 }

--- a/lib/parse-config.js
+++ b/lib/parse-config.js
@@ -1,0 +1,24 @@
+'use strict';
+
+/**
+ * Dependencies
+ */
+
+var fs = require('fs');
+var yaml = require('yamljs');
+
+
+/**
+ * Expose `parse-config`
+ */
+
+module.exports = parseConfig;
+
+
+/**
+ * Parse the YAML config file
+ */
+
+function parseConfig (path) {
+	return yaml.parse(fs.readFileSync(path, 'utf-8'));
+}


### PR DESCRIPTION
Other properties will be added in the near future. Instead of parsing the config every time in every method that needs information out of the config file, it would be cleaner to do it only once.

I added a new `parse-config.js` file because we can add validation if we want (is the language supported for example).