### PR TITLE
use `npm ci` when possible

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -8,7 +8,7 @@ const pify = require('pify');
 const writeFile = pify(fs.writeFile);
 
 module.exports = context => {
-	const version = parseInt(context.version.split(/\./g)[0])
+	const version = parseInt(context.version.split(/\./g)[0], 10);
 
 	const dockerfile = [
 		`FROM node:${context.version}`,

--- a/lib/build.js
+++ b/lib/build.js
@@ -8,23 +8,41 @@ const pify = require('pify');
 const writeFile = pify(fs.writeFile);
 
 module.exports = context => {
+	const version = parseInt(context.version.split(/\./g)[0])
+
 	const dockerfile = [
 		`FROM node:${context.version}`,
 		'WORKDIR /usr/src/app',
 		'ARG NODE_ENV',
 		'ENV NODE_ENV $NODE_ENV',
-		'COPY package.json .',
-		'RUN npm install',
-		'COPY . .',
+		'COPY . .'
+	];
+
+	if (version <= 7) {
+		dockerfile.push(
+			'RUN npm install'
+		);
+	} else if (version <= 9) {
+		dockerfile.push(
+			'RUN npm i -g npm',
+			'RUN npm ci'
+		);
+	} else {
+		dockerfile.push(
+			'RUN npm ci'
+		);
+	}
+
+	dockerfile.push(
 		'CMD ["npm", "start"]'
-	].join('\n');
+	);
 
 	const tmpPath = path.join(context.cwd, `.${context.version}.dockerfile`);
 
 	const image = `test-${context.name}-${context.version}`;
 	const options = {cwd: context.cwd};
 
-	return writeFile(tmpPath, dockerfile, 'utf8')
+	return writeFile(tmpPath, dockerfile.join('\n'), 'utf8')
 		.then(() => exec('docker', ['build', '-t', image, '-f', tmpPath, '.'], options))
 		.then(() => context);
 };

--- a/lib/main.js
+++ b/lib/main.js
@@ -45,11 +45,15 @@ module.exports = ({cwd}) => {
 	let originalDockerIgnore;
 	if (fs.existsSync(filePath('.dockerignore'))) {
 		originalDockerIgnore = fs.readFileSync(filePath('.dockerignore'));
-	} else {
+	} else if (fs.existsSync(filePath('.gitignore'))) {
 		copyFile.sync(filePath('.gitignore'), filePath('.dockerignore'));
 	}
 
-	fs.appendFileSync(filePath('.dockerignore'), '.*.dockerfile');
+	fs.appendFileSync(filePath('.dockerignore'), [
+		'',
+		'.*.dockerfile',
+		'node_modules'
+	].join('\n'));
 
 	const config = parseConfig(filePath('.travis.yml'));
 	const language = config.language || 'node_js';


### PR DESCRIPTION
This change tries to use `npm ci` when it's possible.
It also make sure that `node_modules` is not copied.